### PR TITLE
Modify PITCHME

### DIFF
--- a/meetings/20200625/PITCHME.md
+++ b/meetings/20200625/PITCHME.md
@@ -31,7 +31,7 @@
 @snapend
 
 @snap[south-east]
-![IMAGE](assets/img/current_server.png)
+![IMAGE](/meetings/20200625/assets/img/current_server.png)
 @snapend
 
 ---


### PR DESCRIPTION
GitPitchのスライドで画像が読み込めない件の修正を行いました。

feature/gitpitch-picsブランチのスライドを閲覧する方法がわからなかったのでtestブランチを一時的に作成していますが、
testブランチは例外的に複製したものなので、feature/gitpitch-picsブランチでからプルリクエストを投げます。